### PR TITLE
Add nginx proxy for ssr in platform

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,10 @@
 FROM node:10
 WORKDIR /app
+
+# Setup proxy to API used in saleor-platform
+RUN apt-get update && apt-get install -y nginx
+COPY ./nginx/dev.conf /etc/nginx/conf.d/default.conf
+
 COPY package*.json ./
 RUN npm install
 COPY . .

--- a/nginx/dev.conf
+++ b/nginx/dev.conf
@@ -1,0 +1,9 @@
+server {
+    listen 8000;
+    
+    location / {
+        proxy_pass http://api:8000/;
+        proxy_set_header Host $host:$server_port;
+        proxy_set_header X-Forwarded-For $remote_addr;
+    }
+}


### PR DESCRIPTION
I want to merge this change because I want to resolve the networking issue in the Saleor platform.

In nutshell:
- browser can reach API endpoint with "localhost:8000" URL
- ssr from within the container need to use "API:8000" URL

This change add nginx proxy for the dev container which proxy `localhost:8000` to `api:8000`.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/
